### PR TITLE
Travis CI Python Integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python:
+  - "2.7"
+  - "3.4"
+  - "3.5"
+  - "3.6"      # current default Python on Travis CI
+  - "3.7"
+  - "3.8"
+# command to run tests
+script:
+  - pytest


### PR DESCRIPTION
Integrates Travis CI but not configured for project due to lack of content. Set up for Python versions.